### PR TITLE
Don't install all for griptape in langchain sample

### DIFF
--- a/langchain-calculator/requirements.txt
+++ b/langchain-calculator/requirements.txt
@@ -1,4 +1,4 @@
 python-dotenv==1.0.1
 langchain==0.1.19
 langchain-openai==0.1.6
-griptape[all]==0.28.2
+griptape==0.28.2


### PR DESCRIPTION
* Don't install all for griptape in langchain sample
  * Installing all takes a while and is unnecessary for this sample. We should consider this change for the other samples as well