### PR TITLE
passing required environment vars

### DIFF
--- a/griptape-aws-bill-pdf-to-csv/README.md
+++ b/griptape-aws-bill-pdf-to-csv/README.md
@@ -1,6 +1,6 @@
 This sample takes a Bucket and Asset that represent an AWS Bill PDF stored in Griptape Cloud and converts the bill into a CSV. Each item in the bill is converted to a row in the CSV. The CSV is uploaded to the Bucket as a new Asset in addition to being returned by the Structure as a ListArtifact. This sample demonstrates both Griptape Cloud's Bucket and Asset resources and how Griptape can be used to automate previously manual/hardcoded processes. One such process is identifying if a PDF value with identical formatting is a `AWS Region` or an `AWS Service`.
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-aws-bill-pdf-to-csv&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-aws-bill-pdf-to-csv&type=sample&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 ## Requirements
 

--- a/griptape-chat-memory-agent/README.md
+++ b/griptape-chat-memory-agent/README.md
@@ -1,6 +1,6 @@
 This sample allows you to deploy a Griptape Agent configured with the Griptape Cloud Conversation Memory Driver, Ruleset Driver, and Knowledge Base Tool.
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-chat-memory-agent&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-chat-memory-agent&type=sample&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 ## Requirements
 

--- a/griptape-csv-filter/README.md
+++ b/griptape-csv-filter/README.md
@@ -1,6 +1,6 @@
 This sample takes in a S3 URI pointing at a spreadsheet file and filters the spreadsheet only to relevant columns based on the natural language criteria you specify. It does this while keeping the spreadsheet data "off prompt" and away from the LLM if you wish to keep the spreadsheet contents away from 3P model providers. It will then write the file back to the same S3 bucket your input file exists in under a folder called `output`.
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-csv-filter&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-csv-filter&type=sample&env-var=ANTHROPIC_API_KEY&env-var=GT_CLOUD_API_KEY&env-var=AWS_ACCESS_KEY_ID&env-var=AWS_SECRET_ACCESS_KEY)
 
 ## Requirements
 

--- a/griptape-find-replace-transform/README.md
+++ b/griptape-find-replace-transform/README.md
@@ -1,6 +1,6 @@
 This sample takes in any text input, find a specific word or phrase in that input, and replaces it with a different word or phrase. It is intended to serve as an example of a Structure as a Transform to use with [Griptape Cloud Data Sources](https://docs.griptape.ai/stable/griptape-cloud/data-sources/create-data-source/).
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-find-replace-transform&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-find-replace-transform&type=sample&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 ## Requirements
 

--- a/griptape-model-switcher/README.md
+++ b/griptape-model-switcher/README.md
@@ -1,6 +1,6 @@
 This sample allows you to switch between three different providers and models with a simple explanation prompt in order to contrast responses. You can specify provider with the `-p` parameter and choose between `google`, `openai`, and `anthropic`. Read more about [Griptape's Structure Config](https://docs.griptape.ai/stable/griptape-framework/structures/configs/) to see what other providers Griptape is integrated with.
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-model-switcher&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-model-switcher&type=sample&env-var=OPENAI_API_KEY&env-var=ANTHROPIC_API_KEY&env-var=GOOGLE_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 ## Requirements
 

--- a/griptape-multi-agent-workflows/README.md
+++ b/griptape-multi-agent-workflows/README.md
@@ -14,7 +14,7 @@ This example requires three separate structures each with their own configuratio
 
 ### Researcher Agent
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=github-creation&org=griptape-ai&repo=griptape-sample-structures&branch=main&structure-config-file=griptape-multi-agent-workflows/structure_config_researcher.yaml&name=Researcher)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=github-creation&org=griptape-ai&repo=griptape-sample-structures&branch=main&structure-config-file=griptape-multi-agent-workflows/structure_config_researcher.yaml&name=Researcher&env-var=GOOGLE_API_SEARCH_ID&env-var=GOOGLE_API_KEY&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 ```
 GOOGLE_API_SEARCH_ID=<id>
@@ -25,7 +25,7 @@ GT_CLOUD_API_KEY=<key>
 
 ### Writer Agent
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=github-creation&org=griptape-ai&repo=griptape-sample-structures&branch=main&structure-config-file=griptape-multi-agent-workflows/structure_config_writer.yaml&name=Writer)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=github-creation&org=griptape-ai&repo=griptape-sample-structures&branch=main&structure-config-file=griptape-multi-agent-workflows/structure_config_writer.yaml&name=Writer&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 ```
 OPENAI_API_KEY=<key>
@@ -34,7 +34,7 @@ GT_CLOUD_API_KEY=<key>
 
 ### Main Workflow
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=github-creation&org=griptape-ai&repo=griptape-sample-structures&branch=main&structure-config-file=griptape-multi-agent-workflows/structure_config_workflow.yaml&name=Workflow)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=github-creation&org=griptape-ai&repo=griptape-sample-structures&branch=main&structure-config-file=griptape-multi-agent-workflows/structure_config_workflow.yaml&name=Workflow&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY&env-var=GT_RESEARCH_STRUCTURE_ID&env-var=GT_WRITER_STRUCTURE_ID)
 
 ```
 OPENAI_API_KEY=<key>

--- a/griptape-observability/README.md
+++ b/griptape-observability/README.md
@@ -1,6 +1,6 @@
 This sample instruments a prompt-replying Griptape Agent with the [GriptapeCloudObservabilityDriver](https://docs.griptape.ai/latest/griptape-framework/drivers/observability-drivers/#griptape-cloud). The agent itself is as simple as it gets, this sample's purpose is to demonstrate how the observability can be introduced to Structures.
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-observability&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-observability&type=sample&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 ## Requirements
 

--- a/griptape-off-prompt/README.md
+++ b/griptape-off-prompt/README.md
@@ -2,7 +2,7 @@ This sample summarizes your website of choice into a text message to a friend. Y
 
 To learn more, see the [Griptape blog post on Task Memory and Off-Prompt](https://www.griptape.ai/blog/the-power-of-task-memory-and-off-prompt-tm).
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-off-prompt&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-off-prompt&type=sample&env-var=ANTHROPIC_API_KEY&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 > ⚠️ **NOTE:** The repository URL is hardcoded to griptape-ai in the Deploy to Griptape Cloud button. It is not dynamically updated as a variable. If you fork this repo, update the URL accordingly. 
 > 

--- a/griptape-slack-handler/README.md
+++ b/griptape-slack-handler/README.md
@@ -2,7 +2,7 @@
 
 Fully deployable slack event handler deployable to a Griptape Cloud Structure.
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-slack-handler&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=griptape-slack-handler&type=sample&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 ## Requirements
 

--- a/langchain-calculator/README.md
+++ b/langchain-calculator/README.md
@@ -1,6 +1,6 @@
 This example is basic Langchain code, but mainly intended to show you how you could deploy and host your Langchain code on Griptape Cloud.
 
-[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=langchain-calculator&type=sample)
+[![Deploy_to_Griptape](https://github.com/griptape-ai/griptape-cloud/assets/2302515/4fd57873-5c93-44a8-8fa3-ac1bf7d73bcc)](https://cloud.griptape.ai/structures/create?sample-name=langchain-calculator&type=sample&env-var=OPENAI_API_KEY&env-var=GT_CLOUD_API_KEY)
 
 > ⚠️ **NOTE:** The repository URL is hardcoded to griptape-ai in the Deploy to Griptape Cloud button. It is not dynamically updated as a variable. If you fork this repo, update the URL accordingly. 
 > 


### PR DESCRIPTION
Deploy buttons now pass the required environment variables.

Multi-agent is broken. Needs code on the cloud. 