### PR TITLE
allow ommission of -d for input when running either locally or on cloud

### DIFF
--- a/griptape_aws_bill_pdf_to_csv/README.md
+++ b/griptape_aws_bill_pdf_to_csv/README.md
@@ -40,6 +40,7 @@ python download.py -b <bucket_id> -p <local_file_path> -d <workdir> -n <asset_fi
 ### Griptape Cloud
 
 You can create a run via the API or the UI. When creating runs in the UI, you will need to specify parameters on their own lines.
+`workdir` should be a relative path to the folder within the bucket containing the PDF; if `workdir` is not specified, the default will be the root of the Bucket.
 
 ```
 -b

--- a/griptape_aws_bill_pdf_to_csv/structure.py
+++ b/griptape_aws_bill_pdf_to_csv/structure.py
@@ -148,7 +148,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "-d",
         "--workdir",
-        default=None,
+        default="",
         help="The working directory location of PDF and CSV in the Griptape Cloud Bucket.",
     )
     parser.add_argument(
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         api_key=get_gtc_api_key(),
         base_url=get_gtc_base_url(),
         bucket_id=bucket_id,
-        workdir=workdir,
+        workdir=workdir or "",
     )
 
     loader = AWSBillPdfLoader(file_manager_driver=gtc_file_manager_driver)

--- a/griptape_aws_bill_pdf_to_csv/structure.py
+++ b/griptape_aws_bill_pdf_to_csv/structure.py
@@ -189,7 +189,7 @@ if __name__ == "__main__":
         api_key=get_gtc_api_key(),
         base_url=get_gtc_base_url(),
         bucket_id=bucket_id,
-        workdir=workdir or "",
+        workdir=workdir,
     )
 
     loader = AWSBillPdfLoader(file_manager_driver=gtc_file_manager_driver)


### PR DESCRIPTION
changed the default in the parser from none to an empty string, fixing the error that occurred when a user didn't input an argument for -d